### PR TITLE
通知のN+1を解消

### DIFF
--- a/golang/notifier.go
+++ b/golang/notifier.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/x509"
+	"database/sql"
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
@@ -120,9 +121,10 @@ func SendWebPush(vapidKey *ecdsa.PrivateKey, notificationPB *resources.Notificat
 	return nil
 }
 
-func getPushSubscriptionsByContestantIDs(ctx context.Context, db *sqlx.DB, contestantIDs []string) (subscriptions []*PushSubscription, err error) {
+func getPushSubscriptionsByContestantIDs(ctx context.Context, db *sqlx.DB, contestantIDs []string) ([]*PushSubscription, error) {
+	var subscriptions []*PushSubscription
 	if len(contestantIDs) == 0 {
-		return
+		return nil, sql.ErrNoRows
 	}
 	query, args, err := sqlx.In("SELECT * FROM `push_subscriptions` WHERE `contestant_id` IN (?)", contestantIDs)
 	if err != nil {
@@ -136,7 +138,7 @@ func getPushSubscriptionsByContestantIDs(ctx context.Context, db *sqlx.DB, conte
 	if err != nil {
 		return nil, err
 	}
-	return
+	return subscriptions, nil
 }
 
 func (n *Notifier) NotifyClarificationAnswered(ctx context.Context, db *sqlx.DB, c *Clarification, updated bool) error {

--- a/golang/notifier.go
+++ b/golang/notifier.go
@@ -203,14 +203,6 @@ func (n *Notifier) NotifyClarificationAnswered(ctx context.Context, db *sqlx.DB,
 				log.Errorf("notify: %w", err)
 				continue
 			}
-			_, err = db.ExecContext(ctx,
-				"UPDATE `notifications` SET `read` = TRUE WHERE `contestant_id` = ? AND `read` = FALSE",
-				pushSubscription.ContestantID,
-			)
-			if err != nil {
-				log.Errorf("notify: %w", err)
-				continue
-			}
 		}
 	}
 	return nil
@@ -266,14 +258,6 @@ func (n *Notifier) NotifyBenchmarkJobFinished(ctx context.Context, db *sqlx.DB, 
 					continue
 				}
 			}
-			_, err = db.ExecContext(ctx,
-				"UPDATE `notifications` SET `read` = TRUE WHERE `contestant_id` = ? AND `read` = FALSE",
-				pushSubscription.ContestantID,
-			)
-			if err != nil {
-				log.Errorf("notify: %w", err)
-				continue
-			}
 		}
 	}
 	return nil
@@ -285,8 +269,9 @@ func (n *Notifier) notify(ctx context.Context, db sqlx.ExtContext, notificationP
 		return nil, fmt.Errorf("marshal notification: %w", err)
 	}
 	encodedMessage := base64.StdEncoding.EncodeToString(m)
+	// プッシュ通知なのでもう読まれたものとみなす
 	res, err := db.ExecContext(ctx,
-		"INSERT INTO `notifications` (`contestant_id`, `encoded_message`, `read`, `created_at`, `updated_at`) VALUES (?, ?, FALSE, NOW(6), NOW(6))",
+		"INSERT INTO `notifications` (`contestant_id`, `encoded_message`, `read`, `created_at`, `updated_at`) VALUES (?, ?, TRUE, NOW(6), NOW(6))",
 		contestantID,
 		encodedMessage,
 	)

--- a/golang/notifier.go
+++ b/golang/notifier.go
@@ -167,7 +167,7 @@ func (n *Notifier) NotifyClarificationAnswered(ctx context.Context, db *sqlx.DB,
 		}
 	}
 	var contestantIDs []string
-	var contestantIDToTeamIDMap map[string]int64
+	contestantIDToTeamIDMap := make(map[string]int64)
 	for _, contestant := range contestants {
 		contestantIDs = append(contestantIDs, contestant.ID)
 		contestantIDToTeamIDMap[contestant.ID] = contestant.TeamID


### PR DESCRIPTION
```
23:59:03.708361 ===> PREPARE
23:59:13.083675 ===> LOAD
00:00:23.083332 ===> VALIDATION
00:00:28.668642 ===> SCORE
Count: 
  admin-answer-clarification: 299
  admin-get-clarification: 299
  admin-get-clarifications: 69
  audience-get-dashboard: 26096
  create-team: 30
  enqueue-benchmark: 912
  finish-benchmark: 897
  get-clarification: 321
  get-dashboard: 1500
  join-member: 60
  list-notifications: 16288
  post-clarification: 321
  push-notifications: 4870
  resolve-clarification: 298
(14950 * 1.2) + 2609 - 0(err: 0, timeout: 0)
Pass: true / score: 20549 (20549 - 0)
```