### PR TITLE
感想戦: benchmark_jobs.team_id, created_atにインデックスを貼る

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -43,6 +43,7 @@ CREATE TABLE `benchmark_jobs` (
 ALTER TABLE `benchmark_jobs` ADD INDEX idx1 (`team_id`,`id`);
 ALTER TABLE `benchmark_jobs` ADD INDEX idx2 (`status`,`team_id`,`id`);
 ALTER TABLE `benchmark_jobs` ADD INDEX idx3 (`status`,`team_id`,`finished_at`);
+ALTER TABLE `benchmark_jobs` ADD INDEX `team_id_created_at` (`team_id`, `created_at` DESC);
 
 DROP TABLE IF EXISTS `clarifications`;
 CREATE TABLE `clarifications` (


### PR DESCRIPTION
filesortなくす
```
mysql> EXPLAIN SELECT * FROM `benchmark_jobs` WHERE `team_id` = 10 ORDER BY `created_at` DESC\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: benchmark_jobs
   partitions: NULL
         type: ref
possible_keys: idx1
          key: idx1
      key_len: 8
          ref: const
         rows: 39
     filtered: 100.00
        Extra: Using filesort
1 row in set, 1 warning (0.00 sec)

mysql> ALTER TABLE `benchmark_jobs` ADD INDEX `team_id_created_at` (`team_id`, `created_at` DESC);
Query OK, 0 rows affected (0.04 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> EXPLAIN SELECT * FROM `benchmark_jobs` WHERE `team_id` = 10 ORDER BY `created_at` DESC\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: benchmark_jobs
   partitions: NULL
         type: ref
possible_keys: idx1,team_id_created_at
          key: team_id_created_at
      key_len: 8
          ref: const
         rows: 39
     filtered: 100.00
        Extra: NULL
1 row in set, 1 warning (0.00 sec)

mysql>
```