### PR TITLE
感想戦: 学生チームかどうかフラグをテーブルに切り出す

### DIFF
--- a/golang/cmd/xsuportal/main.go
+++ b/golang/cmd/xsuportal/main.go
@@ -1060,7 +1060,7 @@ func (*RegistrationService) JoinTeam(e echo.Context) error {
 	return writeProto(e, http.StatusOK, &registrationpb.JoinTeamResponse{})
 }
 
-func insertOrUpdateTeamStudentFlags(ctx context.Context, db sqlx.ExtContext, team *xsuportal.Team, contestant *xsuportal.Contestant) error {
+func insertOrUpdateTeamStudentFlags(ctx context.Context, db sqlx.ExecerContext, team *xsuportal.Team, contestant *xsuportal.Contestant) error {
 	_, err := db.ExecContext(ctx,
 		`
 		INSERT INTO team_student_flags (team_id, student) VALUES

--- a/golang/cmd/xsuportal/main.go
+++ b/golang/cmd/xsuportal/main.go
@@ -1068,9 +1068,9 @@ func insertOrUpdateTeamStudentFlags(ctx context.Context, db sqlx.ExecerContext, 
 	}
 	_, err := db.ExecContext(ctx,
 		`
-		INSERT INTO team_student_flags (team_id, student) VALUES
-		(?, (SELECT SUM(student) = COUNT(*) FROM contestants WHERE team_id = ?))
-		ON DUPLICATE KEY UPDATE student = VALUES(student)
+		INSERT INTO team_student_flags (team_id, student, created_at, updated_at) VALUES
+		(?, (SELECT SUM(student) = COUNT(*) FROM contestants WHERE team_id = ?), NOW(6), NOW(6))
+		ON DUPLICATE KEY UPDATE student = VALUES(student), updated_at = VALUES(updated_at)
 		`,
 		contestant.TeamID.Int64,
 		contestant.TeamID.Int64,

--- a/golang/cmd/xsuportal/main.go
+++ b/golang/cmd/xsuportal/main.go
@@ -1050,7 +1050,7 @@ func (*RegistrationService) JoinTeam(e echo.Context) error {
 	if err != nil {
 		return fmt.Errorf("update contestant: %w", err)
 	}
-	err = insertOrUpdateTeamStudentFlags(ctx, tx, *team, contestant)
+	err = insertOrUpdateTeamStudentFlags(ctx, tx, &team, contestant)
 	if err != nil {
 		return fmt.Errorf("update team_student_flags: %w", err)
 	}

--- a/golang/cmd/xsuportal/main.go
+++ b/golang/cmd/xsuportal/main.go
@@ -919,7 +919,7 @@ func (*RegistrationService) CreateTeam(e echo.Context) error {
 	}
 	defer conn.Close()
 
-	_, err = conn.ExecContext(ctx, "LOCK TABLES `teams` WRITE, `contestants` WRITE")
+	_, err = conn.ExecContext(ctx, "LOCK TABLES `teams` WRITE, `contestants` WRITE, `team_student_flags` WRITE")
 	if err != nil {
 		return fmt.Errorf("lock tables: %w", err)
 	}

--- a/golang/cmd/xsuportal/main.go
+++ b/golang/cmd/xsuportal/main.go
@@ -1062,6 +1062,10 @@ func (*RegistrationService) JoinTeam(e echo.Context) error {
 }
 
 func insertOrUpdateTeamStudentFlags(ctx context.Context, db sqlx.ExecerContext, contestant *xsuportal.Contestant) error {
+	if !contestant.TeamID.Valid {
+		// do nothing
+		return nil
+	}
 	_, err := db.ExecContext(ctx,
 		`
 		INSERT INTO team_student_flags (team_id, student) VALUES

--- a/golang/cmd/xsuportal/main.go
+++ b/golang/cmd/xsuportal/main.go
@@ -985,7 +985,8 @@ func (*RegistrationService) CreateTeam(e echo.Context) error {
 	if err != nil {
 		return fmt.Errorf("update team: %w", err)
 	}
-	err = insertOrUpdateTeamStudentFlags(ctx, conn, *team, contestant)
+	contestant.TeamID = sql.NullInt64{Int64: teamID, Valid: true}
+	err = insertOrUpdateTeamStudentFlags(ctx, conn, contestant)
 	if err != nil {
 		return fmt.Errorf("update team_student_flags: %w", err)
 	}
@@ -1050,7 +1051,7 @@ func (*RegistrationService) JoinTeam(e echo.Context) error {
 	if err != nil {
 		return fmt.Errorf("update contestant: %w", err)
 	}
-	err = insertOrUpdateTeamStudentFlags(ctx, tx, &team, contestant)
+	err = insertOrUpdateTeamStudentFlags(ctx, tx, contestant)
 	if err != nil {
 		return fmt.Errorf("update team_student_flags: %w", err)
 	}
@@ -1060,7 +1061,7 @@ func (*RegistrationService) JoinTeam(e echo.Context) error {
 	return writeProto(e, http.StatusOK, &registrationpb.JoinTeamResponse{})
 }
 
-func insertOrUpdateTeamStudentFlags(ctx context.Context, db sqlx.ExecerContext, team *xsuportal.Team, contestant *xsuportal.Contestant) error {
+func insertOrUpdateTeamStudentFlags(ctx context.Context, db sqlx.ExecerContext, contestant *xsuportal.Contestant) error {
 	_, err := db.ExecContext(ctx,
 		`
 		INSERT INTO team_student_flags (team_id, student) VALUES
@@ -1110,7 +1111,7 @@ func (*RegistrationService) UpdateRegistration(e echo.Context) error {
 		contestant.ID,
 	)
 	if team.LeaderID.Valid {
-		err = insertOrUpdateTeamStudentFlags(ctx, tx, team, contestant)
+		err = insertOrUpdateTeamStudentFlags(ctx, tx, contestant)
 		if err != nil {
 			return fmt.Errorf("update team_student_flags: %w", err)
 		}
@@ -1164,7 +1165,7 @@ func (*RegistrationService) DeleteRegistration(e echo.Context) error {
 		}
 	}
 	if team.LeaderID.Valid {
-		err = insertOrUpdateTeamStudentFlags(ctx, tx, team, contestant)
+		err = insertOrUpdateTeamStudentFlags(ctx, tx, contestant)
 		if err != nil {
 			return fmt.Errorf("update team_student_flags: %w", err)
 		}

--- a/golang/cmd/xsuportal/main.go
+++ b/golang/cmd/xsuportal/main.go
@@ -1068,8 +1068,8 @@ func insertOrUpdateTeamStudentFlags(ctx context.Context, db sqlx.ExecerContext, 
 		(?, (SELECT SUM(student) = COUNT(*) FROM contestants WHERE team_id = ?))
 		ON DUPLICATE KEY UPDATE student = VALUES(student)
 		`,
-		contestant.TeamID,
-		contestant.TeamID,
+		contestant.TeamID.Int64,
+		contestant.TeamID.Int64,
 	)
 	if err != nil {
 		return err

--- a/golang/cmd/xsuportal/main.go
+++ b/golang/cmd/xsuportal/main.go
@@ -167,6 +167,7 @@ func (*AdminService) Initialize(e echo.Context) error {
 
 	queries := []string{
 		"TRUNCATE `teams`",
+		"TRUNCATE `team_student_flags`",
 		"TRUNCATE `contestants`",
 		"TRUNCATE `benchmark_jobs`",
 		"TRUNCATE `clarifications`",

--- a/golang/cmd/xsuportal/main.go
+++ b/golang/cmd/xsuportal/main.go
@@ -1581,15 +1581,7 @@ func makeLeaderboardPB(e echo.Context, teamID int64) (*resourcespb.Leaderboard, 
 		"  ) `best_score_job_ids` ON `best_score_job_ids`.`team_id` = `teams`.`id`\n" +
 		"  LEFT JOIN `benchmark_jobs` `best_score_jobs` ON `best_score_jobs`.`id` = `best_score_job_ids`.`id`\n" +
 		"  -- check student teams\n" +
-		"  LEFT JOIN (\n" +
-		"    SELECT\n" +
-		"      `team_id`,\n" +
-		"      (SUM(`student`) = COUNT(*)) AS `student`\n" +
-		"    FROM\n" +
-		"      `contestants`\n" +
-		"    GROUP BY\n" +
-		"      `contestants`.`team_id`\n" +
-		"  ) `team_student_flags` ON `team_student_flags`.`team_id` = `teams`.`id`\n" +
+		"  LEFT JOIN `team_student_flags` ON `team_student_flags`.`team_id` = `teams`.`id`\n" +
 		"ORDER BY\n" +
 		"  `latest_score` DESC,\n" +
 		"  `latest_score_marked_at` ASC,\n" +

--- a/golang/cmd/xsuportal/main.go
+++ b/golang/cmd/xsuportal/main.go
@@ -985,7 +985,7 @@ func (*RegistrationService) CreateTeam(e echo.Context) error {
 	if err != nil {
 		return fmt.Errorf("update team: %w", err)
 	}
-	err = insertOrUpdateTeamStudentFlags(ctx, conn, *team, *contestant)
+	err = insertOrUpdateTeamStudentFlags(ctx, conn, *team, contestant)
 	if err != nil {
 		return fmt.Errorf("update team_student_flags: %w", err)
 	}
@@ -1050,7 +1050,7 @@ func (*RegistrationService) JoinTeam(e echo.Context) error {
 	if err != nil {
 		return fmt.Errorf("update contestant: %w", err)
 	}
-	err = insertOrUpdateTeamStudentFlags(ctx, tx, *team, *contestant)
+	err = insertOrUpdateTeamStudentFlags(ctx, tx, *team, contestant)
 	if err != nil {
 		return fmt.Errorf("update team_student_flags: %w", err)
 	}

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -23,6 +23,15 @@ CREATE TABLE `teams` (
   UNIQUE KEY (`leader_id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4;
 
+DROP TABLE IF EXISTS `team_student_flags`;
+CREATE TABLE `team_student_flags` (
+  `team_id` BIGINT NOT NULL PRIMARY KEY,
+  `student` TINYINT(1) NOT NULL DEFAULT FALSE,
+
+  `created_at` DATETIME(6) NOT NULL,
+  `updated_at` DATETIME(6) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4;
+
 DROP TABLE IF EXISTS `benchmark_jobs`;
 CREATE TABLE `benchmark_jobs` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
#39
```
11:40:54.843141 ===> PREPARE
11:41:04.275197 ===> LOAD
11:41:59.251560 ERR: load: http-server-error: 不正な HTTP ステータスコード: 503 (GET: /api/audience/dashboard)
11:42:14.275254 ===> VALIDATION
11:42:19.828066 ===> SCORE
Count: 
  admin-answer-clarification: 298
  admin-get-clarification: 298
  admin-get-clarifications: 78
  audience-get-dashboard: 29909
  create-team: 30
  enqueue-benchmark: 1213
  finish-benchmark: 1193
  get-clarification: 321
  get-dashboard: 1430
  join-member: 60
  list-notifications: 14618
  post-clarification: 321
  push-notifications: 5791
  resolve-clarification: 298
(17770 * 1.2) + 2990 - 550(err: 1, timeout: 559)
Pass: true / score: 23764 (24314 - 550)
```