### PR TITLE
Varnish Grace Modeで /api/audience/dashboard が落ちててもキャッシュから返してほしい感じにする

### DIFF
--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -16,6 +16,7 @@ vcl 4.0;
 backend default {
     .host = "127.0.0.1";
     .port = "9292";
+    .first_byte_timeout = 1.8s;
 }
 
 sub vcl_recv {

--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -37,6 +37,7 @@ sub vcl_backend_response {
 
     if (bereq.url ~ "^/api/audience/dashboard") {
         set beresp.ttl = 1s;
+        set beresp.grace = 1s;
     }
 }
 


### PR DESCRIPTION
参考: [Varnish Grace Modeで非同期にキャッシュを更新する - LCL Engineers' Blog](https://techblog.lclco.com/entry/2018/02/21/100000)