### PR TITLE
感想戦: X-Dashboard-Freezed-Until ヘッダに渡された日時まで GET /api/audience/dashboard をキャッシュする

### DIFF
--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -12,6 +12,8 @@
 # new 4.0 format.
 vcl 4.0;
 
+import std;
+
 # Default backend definition. Set this to point to your content server.
 backend default {
     .host = "127.0.0.1";

--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -38,6 +38,9 @@ sub vcl_backend_response {
     if (bereq.url ~ "^/api/audience/dashboard") {
         set beresp.ttl = 1s;
         set beresp.grace = 1s;
+        if (beresp.http.X-Dashboard-Freezed-Until) {
+            set beresp.ttl = std.time(beresp.http.X-Dashboard-Freezed-Until, now) - now;
+        }
     }
 }
 

--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -44,7 +44,7 @@ sub vcl_backend_response {
         } else {
             set beresp.ttl = 1s;
         }
-        set beresp.http.Cache-Control = "public, max-age=" beresp.ttl;
+        set beresp.http.Cache-Control = "public, max-age=" + std.integer(beresp.ttl);
     }
 }
 

--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -38,11 +38,13 @@ sub vcl_backend_response {
     # and other mistakes your backend does.
 
     if (bereq.url ~ "^/api/audience/dashboard") {
-        set beresp.ttl = 1s;
         set beresp.grace = 1s;
         if (beresp.http.X-Dashboard-Freezed-Until) {
             set beresp.ttl = std.time(beresp.http.X-Dashboard-Freezed-Until, now) - now;
+        } else {
+            set beresp.ttl = 1s;
         }
+        set beresp.http.Cache-Control = "public, max-age=" + beresp.ttl;
     }
 }
 

--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -44,7 +44,7 @@ sub vcl_backend_response {
         } else {
             set beresp.ttl = 1s;
         }
-        set beresp.http.Cache-Control = "public, max-age=" + beresp.ttl;
+        set beresp.http.Cache-Control = "public, max-age=" beresp.ttl;
     }
 }
 

--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -39,8 +39,8 @@ sub vcl_backend_response {
 
     if (bereq.url ~ "^/api/audience/dashboard") {
         set beresp.grace = 1s;
-        if (beresp.http.X-Dashboard-Freezed-Until) {
-            set beresp.ttl = std.time(beresp.http.X-Dashboard-Freezed-Until, now) - now;
+        if (beresp.http.X-Dashboard-Freezed-Until && std.time(beresp.http.X-Dashboard-Freezed-Until, now) - now > 0) {
+            set beresp.ttl = std.time(beresp.http.X-Dashboard-Freezed-Until, now);
         } else {
             set beresp.ttl = 1s;
         }

--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -53,4 +53,9 @@ sub vcl_deliver {
     # response to the client.
     #
     # You can do accounting or modifying the final object here.
+    if (obj.hits != 0) {
+        set resp.http.X-Cache = "HIT";
+    } else {
+        set resp.http.X-Cache = "MISS";
+    }
 }

--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -40,7 +40,7 @@ sub vcl_backend_response {
     if (bereq.url ~ "^/api/audience/dashboard") {
         set beresp.grace = 1s;
         if (beresp.http.X-Dashboard-Freezed-Until && std.time(beresp.http.X-Dashboard-Freezed-Until, now) > now) {
-            set beresp.ttl = std.time(beresp.http.X-Dashboard-Freezed-Until, now);
+            set beresp.ttl = std.time(beresp.http.X-Dashboard-Freezed-Until, now) - now;
         } else {
             set beresp.ttl = 1s;
         }

--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -39,7 +39,7 @@ sub vcl_backend_response {
 
     if (bereq.url ~ "^/api/audience/dashboard") {
         set beresp.grace = 1s;
-        if (beresp.http.X-Dashboard-Freezed-Until && std.time(beresp.http.X-Dashboard-Freezed-Until, now) - now > 0) {
+        if (beresp.http.X-Dashboard-Freezed-Until && std.time(beresp.http.X-Dashboard-Freezed-Until, now) > now) {
             set beresp.ttl = std.time(beresp.http.X-Dashboard-Freezed-Until, now);
         } else {
             set beresp.ttl = 1s;

--- a/golang/cmd/xsuportal/main.go
+++ b/golang/cmd/xsuportal/main.go
@@ -1287,6 +1287,16 @@ func (*AudienceService) Dashboard(e echo.Context) error {
 	if err != nil {
 		return fmt.Errorf("make leaderboard: %w", err)
 	}
+	contestStatus, err := getCurrentContestStatus(e, db)
+	if err != nil {
+		return fmt.Errorf("get current contest status: %w", err)
+	}
+	contestEndsAt := contestStatus.ContestEndsAt
+	contestFreezesAt := contestStatus.ContestFreezesAt
+	now := time.Now()
+	if now.After(contestFreezesAt) {
+		e.Response().Header().Set("X-Dashboard-Freezed-Until", contestEndsAt.Format(http.TimeFormat))
+	}
 	e.Response().Header().Set("Cache-Control", "public, max-age=1")
 	return e.Blob(http.StatusOK, "application/vnd.google.protobuf", leaderboard)
 }


### PR DESCRIPTION
力技か？

```
13:31:50.684594 ===> PREPARE
13:32:00.115293 ===> LOAD
13:33:10.115225 ===> VALIDATION
13:33:15.754050 ===> SCORE
Count: 
  admin-answer-clarification: 316
  admin-get-clarification: 316
  admin-get-clarifications: 78
  audience-get-dashboard: 27322
  create-team: 30
  enqueue-benchmark: 1355
  finish-benchmark: 1338
  get-clarification: 338
  get-dashboard: 1410
  join-member: 60
  list-notifications: 15436
  post-clarification: 338
  push-notifications: 6376
  resolve-clarification: 315
(19350 * 1.2) + 2732 - 600(err: 0, timeout: 650)
Pass: true / score: 25352 (25952 - 600)
```