### PR TITLE
感想戦: Varnishのfirst_byte_timeoutを小さくする

### DIFF
--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -18,7 +18,7 @@ import std;
 backend default {
     .host = "127.0.0.1";
     .port = "9292";
-    .first_byte_timeout = 1s;
+    .first_byte_timeout = 1.2s;
 }
 
 sub vcl_recv {

--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -18,7 +18,7 @@ import std;
 backend default {
     .host = "127.0.0.1";
     .port = "9292";
-    .first_byte_timeout = 1.8s;
+    .first_byte_timeout = 1s;
 }
 
 sub vcl_recv {


### PR DESCRIPTION
backendがtimeoutしたらすぐにキャッシュから返してほしい的な感じです
```
14:32:57.384201 ===> PREPARE
14:33:06.979724 ===> LOAD
14:34:16.979341 ===> VALIDATION
14:34:22.601053 ===> SCORE
Count: 
  admin-answer-clarification: 360
  admin-get-clarification: 360
  admin-get-clarifications: 66
  audience-get-dashboard: 30786
  create-team: 40
  enqueue-benchmark: 1086
  finish-benchmark: 1069
  get-clarification: 390
  get-dashboard: 2000
  join-member: 80
  list-notifications: 20802
  post-clarification: 390
  push-notifications: 6395
  resolve-clarification: 360
(18290 * 1.4) + 3078 - 0(err: 0, timeout: 0)
Pass: true / score: 28684 (28684 - 0)
```