### PR TITLE
GET /api/audience/dashboard をgzip圧縮する

### DIFF
--- a/conf/varnish/default.vcl
+++ b/conf/varnish/default.vcl
@@ -45,6 +45,7 @@ sub vcl_backend_response {
             set beresp.ttl = 1s;
         }
         set beresp.http.Cache-Control = "public, max-age=" + std.integer(beresp.ttl);
+        set beresp.do_gzip = true;
     }
 }
 


### PR DESCRIPTION
```
14:51:24.380589 ===> PREPARE
14:51:34.215891 ===> LOAD
14:52:44.215959 ===> VALIDATION
14:52:49.882606 ===> SCORE
Count: 
  admin-answer-clarification: 390
  admin-get-clarification: 390
  admin-get-clarifications: 65
  audience-get-dashboard: 32173
  create-team: 40
  enqueue-benchmark: 1119
  finish-benchmark: 1107
  get-clarification: 390
  get-dashboard: 2000
  join-member: 80
  list-notifications: 21020
  post-clarification: 390
  push-notifications: 6625
  resolve-clarification: 360
(18670 * 1.4) + 3217 - 0(err: 0, timeout: 0)
Pass: true / score: 29355 (29355 - 0)
```